### PR TITLE
feat: add Proxmox to technology API endpoints

### DIFF
--- a/eof.py
+++ b/eof.py
@@ -14,6 +14,7 @@ technologies = {
     "Nuxt": "https://endoflife.date/api/nuxt.json",
     "Spring Boot": "https://endoflife.date/api/spring-boot.json",
     "Vuetify": "https://endoflife.date/api/vuetify.json"
+    "Proxmox": "https://endoflife.date/api/v1/products/proxmox-ve"
 }
 
 # Dropdown menu for selecting a technology


### PR DESCRIPTION
Include Proxmox in the technologies dictionary to enable fetching
end-of-life data for Proxmox VE. This expands the supported products
and improves coverage for users tracking technology lifecycles.