### PR TITLE
fix(eof): add missing comma in technologies dictionary

### DIFF
--- a/eof.py
+++ b/eof.py
@@ -13,7 +13,7 @@ technologies = {
     "Keycloak": "https://endoflife.date/api/keycloak.json",
     "Nuxt": "https://endoflife.date/api/nuxt.json",
     "Spring Boot": "https://endoflife.date/api/spring-boot.json",
-    "Vuetify": "https://endoflife.date/api/vuetify.json"
+    "Vuetify": "https://endoflife.date/api/vuetify.json",
     "Proxmox": "https://endoflife.date/api/v1/products/proxmox-ve"
 }
 


### PR DESCRIPTION
Add a trailing comma after the Vuetify entry in the technologies
dictionary to ensure proper syntax and prevent potential errors when
adding new entries. This improves code maintainability and consistency.